### PR TITLE
install, build 시점 문제로 인해 cli레포에서 commit-helper 를 제거합니다.

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run commit-helper $1

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "prettier:fix": "prettier --write '**/*.{json,yaml,md,ts,tsx,js,jsx}'",
         "markdownlint": "markdownlint '**/*.md' '#.changeset' '#**/CHANGELOG.md'",
         "markdownlint:fix": "markdownlint --fix '**/*.md' '#.changeset' '#**/CHANGELOG.md'",
-        "commit-helper": "npx @naverpay/commit-helper",
         "clean": "turbo run clean && rm -rf ./node_modules && pnpm i",
         "release:canary": "pnpm run build && changeset publish --no-git-tag",
         "release": "pnpm run build && changeset publish"
@@ -31,7 +30,6 @@
         "@naverpay/eslint-config": "^0.2.0",
         "@naverpay/markdown-lint": "^0.0.2",
         "@naverpay/prettier-config": "^0.0.2",
-        "@naverpay/commit-helper": "workspace:*",
         "@size-limit/preset-big-lib": "^11.0.2",
         "@types/node": "^20.12.7",
         "glob": "^9.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.27.1
-      '@naverpay/commit-helper':
-        specifier: workspace:*
-        version: link:packages/commit-helper
       '@naverpay/eslint-config':
         specifier: ^0.2.0
         version: 0.2.0(@babel/core@7.24.4)(@babel/eslint-parser@7.24.1)(@babel/plugin-proposal-class-properties@7.18.6)(@babel/plugin-transform-react-jsx@7.23.4)(@next/eslint-plugin-next@14.1.4)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.21.0)(eslint-config-eslint@7.0.0)(eslint-config-prettier@9.1.0)(eslint-config-standard@17.1.0)(eslint-plugin-import@2.25.2)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-node@11.1.0)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.34.1)(eslint-plugin-unused-imports@3.1.0)(eslint@8.57.0)(prettier@2.8.8)


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->
[changeset publish action](https://github.com/NaverPayDev/cli/actions/runs/8811343717) 이 실패하여 확인해보니,
`node_modules/.bin/commit-helper` 가 해당 시점에 없어서 에러가 납니다.

해결하려면,
pnpm i(workspace 의존성 설치) -> pnpm build(commit-helper 빌드해서 dist 생성) ->  pnpm i(.bin/commit-helper) 생성 순으로 진행해야하는데, 최초 배포에만 필요하고 배포 프로세스를 변경하기에 번거로움이 있어서 제거하고 배포합니다.

추후에 githook 으로 `npx @naverpay/commit-helper@latest` 를 사용하도록 PR생성하겠습니다.
 