### PR TITLE
Modify workflows to set `SKIP_COMMIT_HELPER_POSTINSTALL: 1`

### DIFF
--- a/.github/workflows/detect-changed-packages.yml
+++ b/.github/workflows/detect-changed-packages.yml
@@ -14,6 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+            SKIP_COMMIT_HELPER_POSTINSTALL: 1
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v3

--- a/.github/workflows/rc.yaml
+++ b/.github/workflows/rc.yaml
@@ -16,6 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SKIP_COMMIT_HELPER_POSTINSTALL: 1
         steps:
             - name: Get PR branch name
               id: get_branch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     release:
         runs-on: ubuntu-latest
+        env:
+            SKIP_COMMIT_HELPER_POSTINSTALL: 1
         steps:
             - name: checkoutRepo
               uses: actions/checkout@v3

--- a/packages/commithelper-go/README.md
+++ b/packages/commithelper-go/README.md
@@ -1,0 +1,153 @@
+# @naverpay/commithelper-go
+
+A Go-based CLI tool to assist your commit messages based on [husky](https://typicode.github.io/husky/) `commit-msg` hook.
+
+## Performance Comparison with @naverpay/commit-helper
+
+`@naverpay/commithelper-go` is a Go-based rewrite of `@naverpay/commit-helper` with significant performance improvements:
+
+- **⚡ Speed**: 5-6x faster execution compared to Node.js version
+- **📦 Memory**: Lower memory footprint due to compiled binary
+- **🚀 Startup**: Instant startup time vs Node.js runtime initialization
+- **🔧 Dependencies**: Zero runtime dependencies after installation
+
+## Installation
+
+```bash
+npm install @naverpay/commithelper-go
+```
+
+Or install globally:
+
+```bash
+npm install -g @naverpay/commithelper-go
+```
+
+## How to use
+
+### .husky/commit-msg
+
+```bash
+npx --yes @naverpay/commithelper-go@latest "$1"
+```
+
+> `@latest` is not necessary but this option always provides latest version of commithelper-go.
+
+### .lefthook.yml
+
+```yaml
+commit-msg:
+  commands:
+    commithelper:
+      run: npx --yes @naverpay/commithelper-go@latest {1}
+```
+
+### Manual execution
+
+```bash
+npx @naverpay/commithelper-go "your commit message"
+```
+
+## What it does
+
+### Tag related issue
+
+> Automatically Add your related github issue number at your commit message through your branch name
+
+```shell
+➜  your-repo git:(feature/1) git add . &&  git commit -m ":memo: test"
+ℹ No staged files match any configured task.
+$ git branch --show-current
+feature/1
+[feature/1 1e70c244f] [#1] :memo: test
+ 1 file changed, 1 insertion(+)
+```
+
+Your issue number is automatically tagged based on your setting (`.commithelperrc.json`)
+
+### Blocking commit
+
+- Blocks direct commit toward `main`, `develop` `master` branch by throwing error on commit attempt.
+- To block specific branches, add at `protect` field on `commithelperrc`.
+
+## Configuration
+
+### commithelperrc
+
+This is Basic rule of `.commithelperrc.json`.
+
+```json
+{
+    "protect": ["main", "master", "develop"],
+    "rules": {
+        "feature": null,
+        "qa": "your-org/your-repo"
+    }
+}
+```
+
+#### rules
+
+- Key of rules field means branch prefix. By `feature` key, this rule is applied to branches named using the `feature/***` pattern.
+- Value represents the repository to be tagged. For example, rule with value 'your-org/your-repo' tags 'your-org/your-repo#1'.
+- A rule with a `null` value tags repository itself.
+
+#### protect
+
+- Defines branch prefixes that are blocked from committing. `main`, `master`, `develop` branch is blocked by default.
+
+### Example
+
+```json
+// .commithelperrc.json
+{
+    "protect": ["epic"],
+    "rules": {
+        "feature": null,
+        "qa": "your-org/your-repo"
+    }
+}
+```
+
+> For example as above,
+>
+> - commit on `feature/1` branch will be tagged as `[#1]`.
+> - commit on `qa/1` branch will be tagged as `[your-org/your-repo#1]`.
+> - direct commit attempt toward `main`, `master`, `develop`, `epic/***` branch will be blocked
+
+## Environment Variables
+
+### SKIP_COMMIT_HELPER_POSTINSTALL
+
+You can skip the postinstall script (binary download) by setting the `SKIP_COMMIT_HELPER_POSTINSTALL` environment variable:
+
+```bash
+SKIP_COMMIT_HELPER_POSTINSTALL=1 npm install @naverpay/commithelper-go
+```
+
+This is useful in environments where:
+
+- Network access is restricted
+- You want to manage binary installation manually
+- Running in CI/CD environments where postinstall scripts should be skipped
+
+## Platform Support
+
+The CLI automatically downloads the appropriate binary for your platform during installation:
+
+- **macOS**: Intel (x64) and Apple Silicon (arm64)
+- **Linux**: x64
+- **Windows**: x64
+
+## Q&A
+
+- What happens if commit has already tagged issue like `[your-org/your-repo#1]`?
+  - `commithelper-go` do not works. Already tagged issue remains unchanged
+- How does commithelper-go behaves on `feature/1_xxx` `feature/1-xxx` patterned branch name?
+  - It works same as `feature/1` branch.
+- What's the difference between `@naverpay/commit-helper` and `@naverpay/commithelper-go`?
+  - `commithelper-go` is a Go-based rewrite with significantly better performance and lower resource usage.
+
+## License
+
+MIT

--- a/packages/commithelper-go/scripts/downloadBinary.js
+++ b/packages/commithelper-go/scripts/downloadBinary.js
@@ -4,6 +4,11 @@ const {existsSync, mkdirSync, readFileSync} = require('fs')
 const {platform, arch} = require('os')
 const {join} = require('path')
 
+if (process.env.SKIP_COMMIT_HELPER_POSTINSTALL) {
+    console.log('Skipping postinstall script as SKIP_COMMIT_HELPER_POSTINSTALL is set.')
+    process.exit(0)
+}
+
 console.log('Starting postinstall script: downloadBinary.js')
 
 // Define the mapping of platform and architecture to the corresponding binary file names


### PR DESCRIPTION
…riable to ignore postinstall script

## Related Issue <!-- Add issue number behind "#" sign -->

- \#

## Describe your changes <!-- Please describe main difference by your pull request -->

- Problem: `pnpm i --frozen-lockfile` trigger postinstall in commithelper-go.
- Solution: Add a environment variable`SKIP_COMMIT_HELPER_POSTINSTALL`

## Request <!-- Key points for reviewers to focus on (or helpful reference to understand your pull request) -->

-
