### PR TITLE
Fix release workflow to improve commithelper-go publishing logic and streamline asset upload conditions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
             (github.event_name == 'push' ||
              (github.event_name == 'issue_comment' && needs.get-branch.result == 'success'))
         outputs:
-            published: ${{ steps.changesets.outputs.published }}
+            published: ${{ steps.publish_release.outputs.published || steps.publish_canary.outputs.published || steps.publish_rc.outputs.published }}
             commithelperGoWillBePublished: ${{ steps.checkCommitHelperGo.outputs.commithelperGoWillBePublished }}
             packageVersion: ${{ steps.getCommitHelperGoVersion.outputs.packageVersion }}
         env:
@@ -75,23 +75,6 @@ jobs:
             - name: installDependencies
               run: pnpm install --frozen-lockfile
 
-            - name: checkIfCommitHelperGoWasPublished
-              id: checkCommitHelperGo
-              run: |
-                  packageVersion=$(cat packages/commithelper-go/package.json | jq -r '.version')
-                  npmInfo=$(npm info @naverpay/commithelper-go@$packageVersion --json >/dev/null 2>&1 && npm info @naverpay/commithelper-go@$packageVersion --json 2>/dev/null || echo "{}")
-                  isValidJson=$(echo "$npmInfo" | jq empty > /dev/null 2>&1 && echo "true" || echo "false")
-                  if [ "$isValidJson" = "true" ]; then
-                    isPublished=$(echo "$npmInfo" | jq -r 'if .error then "false" else "true" end')
-                  else
-                    isPublished="false"
-                  fi
-                  if [ "$isPublished" = "false" ]; then
-                    echo "commithelperGoWillBePublished=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "commithelperGoWillBePublished=false" >> $GITHUB_OUTPUT
-                  fi
-
             - name: getCommitHelperGoVersion
               id: getCommitHelperGoVersion
               run: |
@@ -102,6 +85,7 @@ jobs:
               run: pnpm build
 
             - name: Publish - Release
+              id: publish_release
               if: github.event_name == 'push'
               uses: NaverPayDev/changeset-actions/publish@main
               with:
@@ -117,6 +101,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
 
             - name: Publish - Canary
+              id: publish_canary
               if: github.event_name == 'issue_comment' && (github.event.comment.body == 'canary-publish' || github.event.comment.body == '/canary-publish')
               uses: NaverPayDev/changeset-actions/canary-publish@main
               with:
@@ -126,9 +111,10 @@ jobs:
                   packages_dir: 'packages'
                   excludes: '.turbo,.github'
                   version_template: '{VERSION}-canary.{DATE}-{COMMITID7}'
-                  create_release: ${{ steps.checkCommitHelperGo.outputs.commithelperGoWillBePublished == 'true' }}
+                  create_release: true
 
             - name: Publish - RC
+              id: publish_rc
               if: github.event_name == 'issue_comment' && (github.event.comment.body == 'rc-publish' || github.event.comment.body == '/rc-publish')
               uses: NaverPayDev/changeset-actions/canary-publish@main
               with:
@@ -142,9 +128,22 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+            - name: Check if commithelper-go was published
+              id: checkCommitHelperGo
+              if: always()
+              run: |
+                  publishedPackages='${{ steps.publish_release.outputs.publishedPackages || steps.publish_canary.outputs.publishedPackages || steps.publish_rc.outputs.publishedPackages }}'
+                  if [ -z "$publishedPackages" ] || [ "$publishedPackages" == "null" ]; then
+                    echo "commithelperGoWillBePublished=false" >> $GITHUB_OUTPUT
+                  elif echo "$publishedPackages" | jq -e '.[] | select(.name == "@naverpay/commithelper-go")' > /dev/null 2>&1; then
+                    echo "commithelperGoWillBePublished=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "commithelperGoWillBePublished=false" >> $GITHUB_OUTPUT
+                  fi
+
     upload-assets:
         needs: release
-        if: needs.release.outputs.commithelperGoWillBePublished == 'true'
+        if: needs.release.outputs.published == 'true' && needs.release.outputs.commithelperGoWillBePublished == 'true'
         uses: ./.github/workflows/release-asset.yaml
         with:
             package: '@naverpay/commithelper-go'


### PR DESCRIPTION
## Related Issue <!-- Add issue number behind "#" sign -->

- \#

## Describe your changes <!-- Please describe main difference by your pull request -->

## Related Issue

- Fixes issues with canary/RC publish not creating releases and uploading assets for commithelper-go

## Describe your changes

This PR fixes the release workflow to properly handle canary/RC publishing and asset uploads for the commithelper-go package.

### Key changes:

1. **Fixed duplicate step IDs**: Added unique IDs to each publish step (`publish_release`, `publish_canary`, `publish_rc`)
2. **Moved package check to post-publish**: Changed from checking if package exists in npm before publishing to checking what was actually published
3. **Use `publishedPackages` output**: Now parses the `publishedPackages` output from publish actions to determine if commithelper-go was published
4. **Always create releases for canary/RC**: Set `create_release: true` for canary publishes (was conditionally false before)
5. **Improved upload-assets conditions**: Added `published == 'true'` check to ensure publish succeeded before uploading assets

### Problem solved:

Before this change:
- The workflow checked if the **base version** (e.g., `1.0.0`) exists in npm
- Canary/RC versions use dynamic versioning (e.g., `1.0.0-rc.20260206-abc1234`)
- If base version already existed, `commithelperGoWillBePublished` was `false`
- Result: No releases created and no assets uploaded for canary/RC publishes ❌

After this change:
- The workflow checks the **actual published packages** from the publish action output
- If commithelper-go was published (regardless of version type), assets are uploaded ✅

## Request

Please review:
- The logic in the "Check if commithelper-go was published" step (lines 131-142)
- The updated job outputs (line 39)
- The new upload-assets condition (line 146)


