### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/loud-breads-raise.md
+++ b/.changeset/loud-breads-raise.md
@@ -1,7 +1,0 @@
----
-"@naverpay/commithelper-go": minor
----
-
-[commithelper-go] Add support for custom commit message templates
-
-PR: [[commithelper-go] Add support for custom commit message templates](https://github.com/NaverPayDev/cli/pull/50)

--- a/packages/commithelper-go/CHANGELOG.md
+++ b/packages/commithelper-go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/commithelper-go
 
+## 1.1.0
+
+### Minor Changes
+
+-   fa045c4: [commithelper-go] Add support for custom commit message templates
+
+    PR: [[commithelper-go] Add support for custom commit message templates](https://github.com/NaverPayDev/cli/pull/50)
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/commithelper-go/package.json
+++ b/packages/commithelper-go/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A CLI tool to assist with commit messages based on branch names and configuration.",
     "bin": {
         "commithelper-go": "bin/cli.js"


### PR DESCRIPTION
# Releases
## @naverpay/commithelper-go@1.1.0

### Minor Changes

-   fa045c4: [commithelper-go] Add support for custom commit message templates

    PR: [\[commithelper-go\] Add support for custom commit message templates](https://github.com/NaverPayDev/cli/pull/50)
