### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/protect-pattern-error-handling.md
+++ b/.changeset/protect-pattern-error-handling.md
@@ -1,5 +1,0 @@
----
-'@naverpay/commithelper-go': patch
----
-
-Return error for invalid protect patterns instead of silently ignoring them

--- a/.changeset/protect-wildcard-pattern.md
+++ b/.changeset/protect-wildcard-pattern.md
@@ -1,5 +1,0 @@
----
-'@naverpay/commithelper-go': minor
----
-
-Support glob-style wildcard patterns in protect option

--- a/packages/commithelper-go/CHANGELOG.md
+++ b/packages/commithelper-go/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @naverpay/commithelper-go
 
+## 1.2.0
+
+### Minor Changes
+
+-   becbe27: Support glob-style wildcard patterns in protect option
+
+### Patch Changes
+
+-   5e93334: Return error for invalid protect patterns instead of silently ignoring them
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/commithelper-go/package.json
+++ b/packages/commithelper-go/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A CLI tool to assist with commit messages based on branch names and configuration.",
     "bin": {
         "commithelper-go": "bin/cli.js"


### PR DESCRIPTION
# Releases
## @naverpay/commithelper-go@1.2.0

### Minor Changes

-   becbe27: Support glob-style wildcard patterns in protect option

### Patch Changes

-   5e93334: Return error for invalid protect patterns instead of silently ignoring them
