### PR TITLE
[CI] commithelper-go 정식 배포 시 upload-assets job이 실행되지 않는 이슈 디버깅 및 수정

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         outputs:
             published: ${{ steps.publish_release.outputs.published || steps.publish_canary.outputs.published || steps.publish_rc.outputs.published }}
             commithelperGoWillBePublished: ${{ steps.checkCommitHelperGo.outputs.commithelperGoWillBePublished }}
-            packageVersion: ${{ steps.checkCommitHelperGo.outputs.publishedVersion || steps.getCommitHelperGoVersion.outputs.packageVersion }}
+            packageVersion: ${{ steps.checkCommitHelperGo.outputs.publishedVersion }}
         env:
             SKIP_COMMIT_HELPER_POSTINSTALL: 1
             GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
@@ -74,12 +74,6 @@ jobs:
 
             - name: installDependencies
               run: pnpm install --frozen-lockfile
-
-            - name: getCommitHelperGoVersion
-              id: getCommitHelperGoVersion
-              run: |
-                  packageVersion=$(cat packages/commithelper-go/package.json | jq -r '.version')
-                  echo "packageVersion=$packageVersion" >> $GITHUB_OUTPUT
 
             - name: buildNodePackages
               run: pnpm build
@@ -132,7 +126,11 @@ jobs:
               id: checkCommitHelperGo
               if: always()
               run: |
+                  echo "publish_release publishedPackages: '${{ steps.publish_release.outputs.publishedPackages }}'"
+                  echo "publish_canary publishedPackages: '${{ steps.publish_canary.outputs.publishedPackages }}'"
+                  echo "publish_rc publishedPackages: '${{ steps.publish_rc.outputs.publishedPackages }}'"
                   publishedPackages='${{ steps.publish_release.outputs.publishedPackages || steps.publish_canary.outputs.publishedPackages || steps.publish_rc.outputs.publishedPackages }}'
+                  echo "resolved publishedPackages: '$publishedPackages'"
                   if [ -z "$publishedPackages" ] || [ "$publishedPackages" == "null" ]; then
                     echo "commithelperGoWillBePublished=false" >> $GITHUB_OUTPUT
                   else
@@ -149,7 +147,7 @@ jobs:
 
     upload-assets:
         needs: release
-        if: needs.release.outputs.published == 'true' && needs.release.outputs.commithelperGoWillBePublished == 'true'
+        if: always() && needs.release.outputs.published == 'true' && needs.release.outputs.commithelperGoWillBePublished == 'true'
         uses: ./.github/workflows/release-asset.yaml
         with:
             package: '@naverpay/commithelper-go'


### PR DESCRIPTION
## 개요

`@naverpay/commithelper-go` 패키지가 `publish_release` step을 통해 정식 배포될 때 `upload-assets` job이 실행되지 않는 이슈를 조사하고 수정합니다.

아직 명확하게 몰라서 이번 정식 배포 때 보겠습니다. (사실 곧 없어지긴 해)

## 변경 사항

### 1. 디버그 로그 추가 (`checkCommitHelperGo` step)

각 publish step의 `publishedPackages` output을 개별 로깅하여 근본 원인을 파악할 수 있도록 합니다.

```
publish_release publishedPackages: '...'
publish_canary publishedPackages: '...'
publish_rc publishedPackages: '...'
resolved publishedPackages: '...'
```

### 2. `upload-assets` job에 `always()` 조건 추가

`release` job 내 특정 step 실패 시에도 `upload-assets` 조건이 평가될 수 있도록 방어적으로 `always()`를 추가합니다.
뒤의 `== 'true'` 조건이 여전히 게이트 역할을 하므로 의도치 않은 실행은 발생하지 않습니다.

### 3. 불필요한 `getCommitHelperGoVersion` step 제거

`checkCommitHelperGo` step에서 `publishedPackages` output의 실제 version을 추출하므로, `package.json`에서 직접 읽는 fallback step은 불필요합니다. `packageVersion` output도 `checkCommitHelperGo.outputs.publishedVersion`만 참조하도록 단순화했습니다.

## 확인 방법

1. 이 PR을 머지하여 main push 트리거 발동
2. `checkCommitHelperGo` step 로그에서 각 `publishedPackages` 값 확인
3. `upload-assets` job 실행 여부 확인
