### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/fix-hyphen-branch-prefix.md
+++ b/.changeset/fix-hyphen-branch-prefix.md
@@ -1,5 +1,0 @@
----
-"@naverpay/commithelper-go": patch
----
-
-fix: branch prefix with hyphens not being matched

--- a/packages/commithelper-go-darwin-arm64/CHANGELOG.md
+++ b/packages/commithelper-go-darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-darwin-arm64
 
+## 1.3.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/commithelper-go-darwin-arm64/package.json
+++ b/packages/commithelper-go-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-darwin-arm64",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "macOS ARM64 binary for @naverpay/commithelper-go",
     "os": [
         "darwin"

--- a/packages/commithelper-go-darwin-x64/CHANGELOG.md
+++ b/packages/commithelper-go-darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-darwin-x64
 
+## 1.3.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/commithelper-go-darwin-x64/package.json
+++ b/packages/commithelper-go-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-darwin-x64",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "macOS x64 binary for @naverpay/commithelper-go",
     "os": [
         "darwin"

--- a/packages/commithelper-go-linux-x64/CHANGELOG.md
+++ b/packages/commithelper-go-linux-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-linux-x64
 
+## 1.3.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/commithelper-go-linux-x64/package.json
+++ b/packages/commithelper-go-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-linux-x64",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Linux x64 binary for @naverpay/commithelper-go",
     "os": [
         "linux"

--- a/packages/commithelper-go-win32-x64/CHANGELOG.md
+++ b/packages/commithelper-go-win32-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-win32-x64
 
+## 1.3.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/commithelper-go-win32-x64/package.json
+++ b/packages/commithelper-go-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-win32-x64",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Windows x64 binary for @naverpay/commithelper-go",
     "os": [
         "win32"

--- a/packages/commithelper-go/CHANGELOG.md
+++ b/packages/commithelper-go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naverpay/commithelper-go
 
+## 1.3.1
+
+### Patch Changes
+
+-   860f7da: fix: branch prefix with hyphens not being matched
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/commithelper-go/package.json
+++ b/packages/commithelper-go/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "A CLI tool to assist with commit messages based on branch names and configuration.",
     "bin": {
         "commithelper-go": "bin/cli.js"


### PR DESCRIPTION
# Releases
## @naverpay/commithelper-go@1.3.1

### Patch Changes

-   860f7da: fix: branch prefix with hyphens not being matched

## @naverpay/commithelper-go-darwin-arm64@1.3.1



## @naverpay/commithelper-go-darwin-x64@1.3.1



## @naverpay/commithelper-go-linux-x64@1.3.1



## @naverpay/commithelper-go-win32-x64@1.3.1


