### PR TITLE
[commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리

### DIFF
--- a/.changeset/dirty-actors-retire.md
+++ b/.changeset/dirty-actors-retire.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/commit-helper": patch
+---
+
+[commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리
+
+PR: [[commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리](https://github.com/NaverPayDev/cli/pull/74)

--- a/packages/commit-helper/bin/cli.ts
+++ b/packages/commit-helper/bin/cli.ts
@@ -1,6 +1,6 @@
 import {exec} from 'child_process'
 import fs from 'fs/promises'
-import {join} from 'path'
+import {isAbsolute, join} from 'path'
 import process from 'process'
 
 import {cosmiconfigSync} from 'cosmiconfig'
@@ -182,7 +182,7 @@ export async function run() {
     }
 
     const commitMessagePath = cli.input[0]
-    const commitFilePath = join(process.cwd(), commitMessagePath)
+    const commitFilePath = isAbsolute(commitMessagePath) ? commitMessagePath : join(process.cwd(), commitMessagePath)
     const commitMessage = await fs.readFile(commitFilePath, 'utf8')
 
     if (!commitMessage) {


### PR DESCRIPTION
## 버그 설명

git worktree 환경에서 `commit-msg` 훅 실행 시 아래 에러가 발생합니다.

```
Error: ENOENT: no such file or directory, open '/absolute/path/.git/worktrees/my-branch/COMMIT_EDITMSG'
```

## 원인

`bin/cli.ts`의 `commitFilePath` 조합 로직:

```typescript
const commitFilePath = join(process.cwd(), commitMessagePath)
```

- **일반 레포**: git이 `$1`을 `.git/COMMIT_EDITMSG` (상대 경로)로 전달 → `path.join` 정상 작동
- **worktree**: git이 `$1`을 `/absolute/path/.git/worktrees/my-branch/COMMIT_EDITMSG` (절대 경로)로 전달 → `path.join(cwd, absolutePath)`은 절대 경로 앞의 `/`를 무시하고 cwd에 붙여버려 잘못된 경로 생성

## 재현 방법

```bash
# worktree 생성
git worktree add ../my-worktree my-branch

cd ../my-worktree
git commit -m "test"
# → ENOENT 에러 발생
```

## 수정 방법

```typescript
import {join, isAbsolute} from 'path'

// 절대 경로이면 그대로 사용, 상대 경로이면 cwd 기준으로 조합
const commitFilePath = isAbsolute(commitMessagePath)
    ? commitMessagePath
    : join(process.cwd(), commitMessagePath)
```