### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/dirty-actors-retire.md
+++ b/.changeset/dirty-actors-retire.md
@@ -1,7 +1,0 @@
----
-"@naverpay/commit-helper": patch
----
-
-[commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리
-
-PR: [[commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리](https://github.com/NaverPayDev/cli/pull/74)

--- a/packages/commit-helper/CHANGELOG.md
+++ b/packages/commit-helper/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/commit-helper
 
+## 1.2.2
+
+### Patch Changes
+
+-   654bc32: [commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리
+
+    PR: [[commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리](https://github.com/NaverPayDev/cli/pull/74)
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/commit-helper/package.json
+++ b/packages/commit-helper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commit-helper",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "help your commit in git",
     "main": "./dist/index.js",
     "repository": {


### PR DESCRIPTION
# Releases
## @naverpay/commit-helper@1.2.2

### Patch Changes

-   654bc32: [commithelper] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리

    PR: [\[commithelper\] fix: git worktree 환경에서 COMMIT_EDITMSG 절대 경로 처리](https://github.com/NaverPayDev/cli/pull/74)
