### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/great-pumas-attack.md
+++ b/.changeset/great-pumas-attack.md
@@ -1,7 +1,0 @@
----
-"@naverpay/commit-helper": patch
----
-
-feat(commit-helper): support local file path in extends
-
-PR: [feat(commit-helper): support local file path in extends](https://github.com/NaverPayDev/cli/pull/84)

--- a/.changeset/ten-lights-heal.md
+++ b/.changeset/ten-lights-heal.md
@@ -1,7 +1,0 @@
----
-"@naverpay/commithelper-go": minor
----
-
-feat(commithelper-go): add extends support for remote config inheritance
-
-PR: [feat(commithelper-go): add extends support for remote config inheritance](https://github.com/NaverPayDev/cli/pull/83)

--- a/packages/commit-helper/CHANGELOG.md
+++ b/packages/commit-helper/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/commit-helper
 
+## 2.0.1
+
+### Patch Changes
+
+-   e937702: feat(commit-helper): support local file path in extends
+
+    PR: [feat(commit-helper): support local file path in extends](https://github.com/NaverPayDev/cli/pull/84)
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/commit-helper/package.json
+++ b/packages/commit-helper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commit-helper",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "help your commit in git",
     "main": "./dist/index.js",
     "repository": {

--- a/packages/commithelper-go-darwin-arm64/CHANGELOG.md
+++ b/packages/commithelper-go-darwin-arm64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-darwin-arm64
 
+## 1.5.0
+
 ## 1.4.0
 
 ## 1.3.1

--- a/packages/commithelper-go-darwin-arm64/package.json
+++ b/packages/commithelper-go-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-darwin-arm64",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "macOS ARM64 binary for @naverpay/commithelper-go",
     "os": [
         "darwin"

--- a/packages/commithelper-go-darwin-x64/CHANGELOG.md
+++ b/packages/commithelper-go-darwin-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-darwin-x64
 
+## 1.5.0
+
 ## 1.4.0
 
 ## 1.3.1

--- a/packages/commithelper-go-darwin-x64/package.json
+++ b/packages/commithelper-go-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-darwin-x64",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "macOS x64 binary for @naverpay/commithelper-go",
     "os": [
         "darwin"

--- a/packages/commithelper-go-linux-x64/CHANGELOG.md
+++ b/packages/commithelper-go-linux-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-linux-x64
 
+## 1.5.0
+
 ## 1.4.0
 
 ## 1.3.1

--- a/packages/commithelper-go-linux-x64/package.json
+++ b/packages/commithelper-go-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-linux-x64",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Linux x64 binary for @naverpay/commithelper-go",
     "os": [
         "linux"

--- a/packages/commithelper-go-win32-x64/CHANGELOG.md
+++ b/packages/commithelper-go-win32-x64/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @naverpay/commithelper-go-win32-x64
 
+## 1.5.0
+
 ## 1.4.0
 
 ## 1.3.1

--- a/packages/commithelper-go-win32-x64/package.json
+++ b/packages/commithelper-go-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go-win32-x64",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Windows x64 binary for @naverpay/commithelper-go",
     "os": [
         "win32"

--- a/packages/commithelper-go/CHANGELOG.md
+++ b/packages/commithelper-go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/commithelper-go
 
+## 1.5.0
+
+### Minor Changes
+
+-   d2714c5: feat(commithelper-go): add extends support for remote config inheritance
+
+    PR: [feat(commithelper-go): add extends support for remote config inheritance](https://github.com/NaverPayDev/cli/pull/83)
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/commithelper-go/package.json
+++ b/packages/commithelper-go/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@naverpay/commithelper-go",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "A CLI tool to assist with commit messages based on branch names and configuration.",
     "bin": {
         "commithelper-go": "bin/cli.js"


### PR DESCRIPTION
# Releases
## @naverpay/commithelper-go@1.5.0

### Minor Changes

-   d2714c5: feat(commithelper-go): add extends support for remote config inheritance

    PR: [feat(commithelper-go): add extends support for remote config inheritance](https://github.com/NaverPayDev/cli/pull/83)

## @naverpay/commit-helper@2.0.1

### Patch Changes

-   e937702: feat(commit-helper): support local file path in extends

    PR: [feat(commit-helper): support local file path in extends](https://github.com/NaverPayDev/cli/pull/84)

## @naverpay/commithelper-go-darwin-arm64@1.5.0



## @naverpay/commithelper-go-darwin-x64@1.5.0



## @naverpay/commithelper-go-linux-x64@1.5.0



## @naverpay/commithelper-go-win32-x64@1.5.0


