### PR TITLE
fix: exclude test files from ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -63,3 +63,7 @@ dist
 apps/docs/docs
 
 .changeset/*
+
+# Test files
+**/*.test.js
+**/*.test.ts

--- a/packages/commit-helper/__test__/cli.test.js
+++ b/packages/commit-helper/__test__/cli.test.js
@@ -1,4 +1,8 @@
-import {getCommitMessageByBranchName, isStringMatchingPatterns, resolveKey, alreadyHasRef} from '../bin/cli.js'
+import {writeFile, mkdtemp, rm} from 'fs/promises'
+import {tmpdir} from 'os'
+import {join} from 'path'
+
+import {getCommitMessageByBranchName, isStringMatchingPatterns, resolveKey, alreadyHasRef, loadExtendsConfig} from '../bin/cli.js'
 import {BRANCH_ISSUE_TAGGING_REGEX} from '../src/constant.js'
 
 describe('브랜치가 commithelper 형식에 맞는지 확인하는 정규식', () => {
@@ -160,11 +164,6 @@ describe('getCommitMessageByBranchName: 우선순위와 멱등', () => {
 })
 
 // ── extends: loadExtendsConfig ────────────────────────────────────────────────
-
-import {loadExtendsConfig} from '../bin/cli.js'
-import {writeFile, mkdtemp, rm} from 'fs/promises'
-import {tmpdir} from 'os'
-import {join} from 'path'
 
 describe('loadExtendsConfig — local file path', () => {
     let dir

--- a/packages/commit-helper/__test__/cli.test.js
+++ b/packages/commit-helper/__test__/cli.test.js
@@ -1,8 +1,4 @@
-import {writeFile, mkdtemp, rm} from 'fs/promises'
-import {tmpdir} from 'os'
-import {join} from 'path'
-
-import {getCommitMessageByBranchName, isStringMatchingPatterns, resolveKey, alreadyHasRef, loadExtendsConfig} from '../bin/cli.js'
+import {getCommitMessageByBranchName, isStringMatchingPatterns, resolveKey, alreadyHasRef} from '../bin/cli.js'
 import {BRANCH_ISSUE_TAGGING_REGEX} from '../src/constant.js'
 
 describe('브랜치가 commithelper 형식에 맞는지 확인하는 정규식', () => {
@@ -164,6 +160,11 @@ describe('getCommitMessageByBranchName: 우선순위와 멱등', () => {
 })
 
 // ── extends: loadExtendsConfig ────────────────────────────────────────────────
+
+import {loadExtendsConfig} from '../bin/cli.js'
+import {writeFile, mkdtemp, rm} from 'fs/promises'
+import {tmpdir} from 'os'
+import {join} from 'path'
 
 describe('loadExtendsConfig — local file path', () => {
     let dir


### PR DESCRIPTION
Excludes `**/*.test.{js,ts}` from ESLint via `.eslintignore`.

Fixes the lint failure introduced after #84 was merged (`import/order` violation in test file).

Since CI runs on base branch due to `pull_request_target`, the base's lint failure needed to be resolved at the source.