### PR TITLE
fix(commithelper-go): add blank line before list in README (MD032)

### DIFF
--- a/packages/commithelper-go/README.md
+++ b/packages/commithelper-go/README.md
@@ -141,6 +141,7 @@ Install the shared config as a dev dependency and reference it via a relative pa
 | `template`    | local wins; falls back to base if local is unset |
 
 **Constraints:**
+
 - Local path: relative paths are resolved from the current working directory (repo root).
 - Remote URL: only `http://` and `https://` are accepted. 10-second timeout.
 - The base config's own `extends` field is **ignored** — no recursive loading.


### PR DESCRIPTION
Fixes markdownlint MD032 error introduced in #83.

`**Constraints:**` heading was immediately followed by a list without a blank line separator.